### PR TITLE
Fix unique id

### DIFF
--- a/custom_components/falcon_pi_player/media_player.py
+++ b/custom_components/falcon_pi_player/media_player.py
@@ -66,7 +66,7 @@ class FalconPiPlayer(MediaPlayerEntity):
         self._media_duration = None
         self._media_position = None
         self._media_position_updated_at = None
-        self._attr_unique_id = "media_player_{name}"
+        self._attr_unique_id = f"media_player_{name}"
         self._available = False
 
     def update(self):


### PR DESCRIPTION
For `self.attr_unique_id` the name of the player wasn't interpolating correctly, preventing multiple players from being added due to the unique id not being unique.

Fixes #4 